### PR TITLE
Remove metadata.xml-dependencie to ftw.simplelayout.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,10 @@
 ftw.addressblock
 ################
 
-This Plone add-on installs a new content type which can be used to display
-address data. It requires ``ftw.simplelayout``.
+*This package is an addon for `ftw.simplelayout <http://github.com/4teamwork/ftw.simplelayout>`_. Please make sure you
+already installed `ftw.simplelayout` on your plone site before installing this addon.*
+
+This add-on installs a new content type which can be used to display address data.
 
 Extras
 ======

--- a/ftw/addressblock/profiles/default/metadata.xml
+++ b/ftw/addressblock/profiles/default/metadata.xml
@@ -2,6 +2,5 @@
 <metadata>
     <version>1000</version>
     <dependencies>
-        <dependency>profile-ftw.simplelayout.contenttypes:default</dependency>
     </dependencies>
 </metadata>

--- a/ftw/addressblock/testing.py
+++ b/ftw/addressblock/testing.py
@@ -27,6 +27,7 @@ class FtwLayer(PloneSandboxLayer):
         z2.installProduct(app, 'ftw.simplelayout')
 
     def setUpPloneSite(self, portal):
+        applyProfile(portal, 'ftw.simplelayout.contenttypes:default')
         applyProfile(portal, 'ftw.addressblock:default')
         applyProfile(portal, 'ftw.addressblock.geo:default')
         applyProfile(portal, 'ftw.addressblock.contact:default')


### PR DESCRIPTION
This package is an addon of ftw.simplelayout and should not install it.