### PR TITLE
make geo location adapter more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make geo location adapter more robust for publisher compatibility. [jone]
 
 
 1.0.1 (2016-08-26)

--- a/ftw/addressblock/geo/adapters.py
+++ b/ftw/addressblock/geo/adapters.py
@@ -19,7 +19,7 @@ class AddressBlockLocationAdapter(object):
         Build a geocodable location string from the AddressBlocks address
         related fields.
         """
-        street = self.context.address.strip()
+        street = (self.context.address or '').strip()
         # Remove Postfach form street, otherwise Google geocoder API will
         # return wrong results.
         street = street.replace('Postfach', '').replace('\r', '').strip()


### PR DESCRIPTION
Make the geo location adapter more robust by expecting the address to be None in order to support ftw.publisher.

When an object is published, events are fired before the field values are set, trigger the geo location lookup.