### PR TITLE
Change string expr. to python expr in addressblock detail view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Change string expr. to python expr in addressblock detail view. 
+  With Chameleon a string expression is evaluated different than without (& --> &amp;).
+  [mathias.leimgruber]
 
 
 1.0.3 (2016-11-01)

--- a/ftw/addressblock/browser/templates/detail.pt
+++ b/ftw/addressblock/browser/templates/detail.pt
@@ -30,7 +30,7 @@
               <div id="map" class="blockwidget-cgmap"
                    tal:attributes="id mapid;
                       style context/@@collectivegeo-macros/map_inline_css;
-                      data-googlejs string:${geosettings/google_maps_js};
+                      data-googlejs python:geosettings.google_maps_js;
                       data-cgeolatitude map_defaults/latitude|nothing;
                       data-cgeolongitude map_defaults/longitude|nothing;
                       data-cgeozoom map_defaults/zoom|nothing;


### PR DESCRIPTION
With Chameleon a string expression is evaluated different than without (& --> &amp;).