### PR TITLE
Make AddressBlock addable on plone site

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make AddressBlock addable on plone site per default [raphael-s]
 
 
 1.0.4 (2017-01-31)
@@ -14,7 +14,7 @@ Changelog
 - Make reading value of the address block's rich text fields more robust.
   [mbaechtold]
 
-- Change string expr. to python expr in addressblock detail view. 
+- Change string expr. to python expr in addressblock detail view.
   With Chameleon a string expression is evaluated different than without (& --> &amp;).
   [mathias.leimgruber]
 

--- a/ftw/addressblock/profiles/default/types/Plone_Site.xml
+++ b/ftw/addressblock/profiles/default/types/Plone_Site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.addressblock.AddressBlock" />
+    </property>
+
+</object>


### PR DESCRIPTION
When `ftw.addressblock` is installed the AddressBlock can now be added to plone site per default.

We don't want an upgrade step for this because we don't want to change how existing deployments handle the AddressBlock.

