### PR TITLE
The "Title" attribute should return utf8 encoded string instead of unicode.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- The "Title" attribute should return utf8 encoded string instead of unicode. [mathias.leimgruber]
 
 
 1.1.1 (2017-11-27)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 
 - The "Title" attribute should return utf8 encoded string instead of unicode. [mathias.leimgruber]
 
+- Pin c.geo versions for plone 4.3.x [mathias.leimgruber]
+
 
 1.1.1 (2017-11-27)
 ------------------

--- a/ftw/addressblock/content/addressblock.py
+++ b/ftw/addressblock/content/addressblock.py
@@ -3,6 +3,7 @@ from ftw.addressblock.interfaces import IAddressBlock
 from plone import api
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
+from plone.dexterity.utils import safe_utf8
 from plone.directives import form
 from zope.i18n import translate
 from zope.interface import implements
@@ -18,7 +19,7 @@ class AddressBlock(Item):
     implements(IAddressBlock)
 
     def Title(self):
-        return self.title or self.fallback_title
+        return safe_utf8(self.title or self.fallback_title)
 
     @property
     def fallback_title(self):

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -4,3 +4,16 @@ extends =
     sources.cfg
 
 package-name = ftw.addressblock
+
+
+[versions]
+collective.geo.behaviour = 1.2
+collective.geo.bundle = 2.3
+collective.geo.contentlocations = 3.1
+collective.geo.geographer = 2.1
+collective.geo.kml = 3.3
+collective.geo.mapwidget = 2.5
+collective.geo.openlayers = 3.2b1
+collective.geo.settings = 3.1
+collective.z3cform.colorpicker = 1.4
+collective.z3cform.mapwidget = 2.1


### PR DESCRIPTION
The `Title` is used in various places on Plone and always assumed that it is a utf-8 encoded string.

For example in the uid_catalog, where a lookup in a Betree happens, holding as key only utf-8 encoded titles. 

If you feed a unicode title, python uses ascii to convert and compare the values. which results in a unicodeDecodeError. if there for example an Umlaut involved. 


This PR also fixes the c.geo versions in order to let the tests pass. 