### PR TITLE
Remove source checkout of ftw.subsite because it was released

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -3,9 +3,3 @@ extends =
     http://kgs.4teamwork.ch/sources.cfg
 
 extensions += mr.developer
-
-auto-checkout =
-    ftw.subsite
-
-[branches]
-ftw.subsite = plone-5.1.x


### PR DESCRIPTION
`ftw.subsite` was released in the meantime and the specified branch does not exist anymore, this resolves in an error when building the dev or test environment. 