### PR TITLE
Fix edit permissions for addressblock

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
+- Fix edit permissions for addressblock [Nachtalb]
 - Add zoomlevel and maplayers support for addressblocks [Nachtalb]
 
 

--- a/ftw/addressblock/profiles/default/types/ftw.addressblock.AddressBlock.xml
+++ b/ftw/addressblock/profiles/default/types/ftw.addressblock.AddressBlock.xml
@@ -49,6 +49,7 @@
     <action title="Edit" action_id="edit" category="object" condition_expr=""
             description="" icon_expr="" link_target=""
             url_expr="string:${object_url}/edit" visible="True">
+            <permission value="Modify portal content"/>
     </action>
 
 </object>

--- a/ftw/addressblock/profiles/default_plone5/types/ftw.addressblock.AddressBlock.xml
+++ b/ftw/addressblock/profiles/default_plone5/types/ftw.addressblock.AddressBlock.xml
@@ -49,6 +49,7 @@
     <action title="Edit" action_id="edit" category="object" condition_expr=""
             description="" icon_expr="" link_target=""
             url_expr="string:${object_url}/edit" visible="True">
+            <permission value="Modify portal content"/>
     </action>
 
 </object>

--- a/ftw/addressblock/upgrades/20190521172501_add_missing_permission_for_editing/types/ftw.addressblock.AddressBlock.xml
+++ b/ftw/addressblock/upgrades/20190521172501_add_missing_permission_for_editing/types/ftw.addressblock.AddressBlock.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<object name="ftw.addressblock.AddressBlock">
+
+  <action title="Edit"
+          action_id="edit"
+          category="object"
+          condition_expr=""
+          description=""
+          icon_expr=""
+          link_target=""
+          url_expr="string:${object_url}/edit"
+          visible="True">
+    <permission value="Modify portal content"/>
+  </action>
+
+</object>

--- a/ftw/addressblock/upgrades/20190521172501_add_missing_permission_for_editing/upgrade.py
+++ b/ftw/addressblock/upgrades/20190521172501_add_missing_permission_for_editing/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddMissingPermissionForEditing(UpgradeStep):
+    """Add missing permission for editing.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
We only want the user to see and "edit" button/link if he actually does have the permission to edit it.